### PR TITLE
フラッシュ機能の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,3 +29,12 @@
 .mw-xl {
   max-width: 1200px;
 }
+
+/* フラッシュ */
+.alert-notice {
+  @extend .alert-success;
+}
+
+.alert-alert {
+  @extend .alert-danger;
+}

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |flash_type, msg|%>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">×</a>
+    <%= msg %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,9 +11,9 @@
   <body>
     <header>
       <%= render "layouts/header" %>
-      <%= render "layouts/flash" %>
     </header>
     <main>
+      <%= render "layouts/flash" %>
       <%# max_width メソッドは application_helper.rb に記載 %>
       <div class="base-container <%= max_width %>">
         <%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
   <body>
     <header>
       <%= render "layouts/header" %>
+      <%= render "layouts/flash" %>
     </header>
     <main>
       <%# max_width メソッドは application_helper.rb に記載 %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2021_08_04_021550) do
   create_table "texts", force: :cascade do |t|
     t.integer "genre", default: 0, null: false
     t.string "title", null: false
-    t.text "content", null: false
+    t.text "contnt", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
close #13

## 実装内容

- フラッシュの表示機能を実装
  - mainタグの下にページ横幅一杯のフラッシュ
  - 部分テンプレート `app/views/layouts/_flash.html.erb`  を作成し読み込むように設定 

## 確認内容

- ログイン時とログアウト時にフラッシュが表示されることを確認

## 参考資料

- [【公式】Bootstrap（Alerts）](https://getbootstrap.jp/docs/4.5/components/alerts/)
- [【やんばるエキスパート教材】メッセージ投稿アプリ（その３）](https://www.yanbaru-code.com/texts/271)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要があれば）

- ログイン時のフラッシュ

![スクリーンショット 2021-08-06 21 00 09](https://user-images.githubusercontent.com/80263479/128510338-b8808d7b-aa7b-4183-b1e9-cc7cc97a29b3.png)

- ログアウト時のフラッシュ

![スクリーンショット 2021-08-06 21 21 40](https://user-images.githubusercontent.com/80263479/128510446-c5fa8075-22da-4c55-b1e9-49a392d6aac2.png)
