### PR TITLE
教材のCSVインポート機能を実装

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2021_08_04_021550) do
   create_table "texts", force: :cascade do |t|
     t.integer "genre", default: 0, null: false
     t.string "title", null: false
-    t.text "contnt", null: false
+    t.text "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,26 @@
+# texts, movies テーブルを再生成（関連付くテーブルを含む）
+%w[texts movies].each do |table_name|
+  ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
+end
+
+require "csv"
+
+CSV.foreach("db/csv_data/movie_data.csv", headers: true) do |row|
+  Movie.create(
+    genre: row["genre"],
+    title: row["title"],
+    url: row["url"]
+  )
+end
+
+CSV.foreach("db/csv_data/text_data.csv", headers: true) do |row|
+  Text.create(
+    genre: row["genre"],
+    title: row["title"],
+    content: row["content"]
+  )
+end
+
 email = "test@example.com"
 password = "password"
 


### PR DESCRIPTION
#10 

# 実装内容

- `db/seeds.rb` の最初に以下を追加
```
# texts, movies テーブルを再生成（関連付くテーブルを含む）
%w[texts movies].each do |table_name|
  ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
end
```
- `db/seeds.rb` に，テキスト教材のCSV（`db/csv_data/text_data.csv`）を読み込み texts テーブルにデータを投入する処理を追加
- `db/seeds.rb` に，動画教材のCSV（`db/csv_data/movie_data.csv`）を読み込み movies テーブルにデータを投入する処理を追加

# 参考文献
- [【やんばるエキスパート教材】CSVインポート](https://www.yanbaru-code.com/texts/217)

# 動作確認
- 以下を実行し，教材データが入っていることを確認
```
rails db:seed
rails c

# Railsコンソール起動後
Text.all
Movie.all
# CSVファイルのデータが入っていることを確認
```