### PR TITLE
railsテキスト教材一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -1,7 +1,3 @@
-.text-page-title {
-  margin: 0 auto;
-  text-align: center;
-}
 .row {
   margin: 0 -15px;
 }

--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -1,0 +1,15 @@
+.text-page-title {
+  margin: 0 auto;
+  text-align: center;
+}
+.row {
+  margin: 0 -15px;
+}
+.card-box {
+  padding: 0 15px;
+}
+.card {
+  margin: 0 auto;
+  max-width: 376px;
+  height: 370px;
+}

--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -1,10 +1,4 @@
-.row {
-  margin: 0 -15px;
-}
-.card-box {
-  padding: 0 15px;
-}
-.card {
+.body-size {
   margin: 0 auto;
   max-width: 376px;
   height: 370px;

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,5 +1,7 @@
 class TextsController < ApplicationController
-  def index; end
+  def index
+    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+  end
 
   def show; end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -8,6 +8,8 @@ class Text < ApplicationRecord
     php: 5
   }
 
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,0 +1,17 @@
+<div class="card-box col-12 col-md-6 col-lg-4">
+    <div class="card border-dark mb-3">
+      <%# 詳細ページ実装後にリンクを下記に記載 %>
+      <%# <a fref=""> %>
+        <div class="card-header p-0">
+          <img class="img-fluid" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg">
+        </div>
+        <div class="card-body text-dark">
+          <div class="read-through-box mb-1">
+            <a href="#" class="btn btn-block btn-secondary">読破済みにする</a>
+          </div>
+          <p class="card-title mt-3 mb-3"><%= text.title %></p>
+          <p class="card-text">【<%= text.genre_i18n  %>】</p>
+        </div>
+      <%# </a> %>
+    </div>
+</div>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,5 +1,5 @@
 <div class="card-box col-12 col-md-6 col-lg-4">
-    <div class="card border-dark mb-3">
+    <div class="card body-size border-dark mb-3">
       <%# 詳細ページ実装後にリンクを下記に記載 %>
       <%# <a fref=""> %>
         <div class="card-header p-0">

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,5 +1,4 @@
-<%# ヘッダー完成後に下記でヘッダー部分のテンプレートを呼ぶ。 %>
-<%# <%= render partial: "layouts/_header.html.erb"%>
+<%= render partial: "layouts/header"%>
 
 <h1 class="text-center mt-2 mb-4">Ruby/Rails <br class="d-sm-none">
   テキスト教材</h1>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,1 +1,8 @@
+<%# ヘッダー完成後に下記でヘッダー部分のテンプレートを呼ぶ。 %>
+<%# <%= render partial: "layouts/_header.html.erb"%>
 
+<h1 class="text-center mt-2 mb-4">Ruby/Rails <br class="d-sm-none">
+  テキスト教材</h1>
+<div class="row">
+  <%= render partial: "text", collection: @texts %>
+</div>


### PR DESCRIPTION
#14 

## 実装内容
タスク #9 #10 #11 完了後に行って下さい
- `app/models/text.rb` に次を定義

```rb
  RAILS_GENRE_LIST  = %w[basic git ruby rails]
```

- Railsテキスト教材の一覧ページを作成  
  - 表示するジャンするは `Text::RAILS_GENRE_LIST` に制限
  - Bootstrapの `Cards` や `Grid System` を用いて数のようなスタイルにすること
  - `each` を使わず 「[コレクションをレンダリング](https://railsguides.jp/layouts_and_rendering.html#%E3%82%B3%E3%83%AC%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E3%83%AC%E3%83%B3%E3%83%80%E3%83%AA%E3%83%B3%E3%82%B0%E3%81%99%E3%82%8B)」を利用しましょう
  - 画像部分は [デフォルト画像](https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg) を表示するのみとする
  - カードの `height` , `max-width` を指定すること
  - テキスト教材ページでしか利用しないスタイルは `app/assets/stylesheets/texts.css` を作成して書き込むこと
  - 検索機能は実装しない
  - カード全体を「詳細ページ」へのリンクにする作業は別タスクとする
  - 「読破済みボタン」はボタンの配置のみとする（機能は別タスクで実装）

![image](https://user-images.githubusercontent.com/80263479/127062476-ebbe82da-1be2-4870-a7c1-fe184177fe41.png)
![image](https://user-images.githubusercontent.com/80263479/127062513-ea77499d-b165-4a27-8764-ac5bd052b32c.png)
![image](https://user-images.githubusercontent.com/80263479/127062549-bbeca417-3332-40b5-8df7-39d8f56cdb99.png)

## 参考文献

- [【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
- [【公式】Booststrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)

## 動作確認

- 画像のようにレスポンシブ対応ができているかどうかを確認
- ブラウザの横幅次第でカードの横幅が長くなりすぎていないかを確認
- PHPのテキスト教材が表示されていないことを確認