### PR TITLE
動画教材の視聴済み機能

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).includes(:watch_progresses).order(:created_at)
   end
 end

--- a/app/controllers/watch_progresses_controller.rb
+++ b/app/controllers/watch_progresses_controller.rb
@@ -1,0 +1,11 @@
+class WatchProgressesController < ApplicationController
+  def create
+    @movie = Movie.find(params[:movie_id])
+    current_user.watch_progresses.create!(movie_id: @movie.id)
+  end
+
+  def destroy
+    @movie = Movie.find(params[:movie_id])
+    current_user.watch_progresses.find_by(movie_id: @movie.id).destroy!
+  end
+end

--- a/app/controllers/watch_progresses_controller.rb
+++ b/app/controllers/watch_progresses_controller.rb
@@ -1,11 +1,15 @@
 class WatchProgressesController < ApplicationController
   def create
-    @movie = Movie.find(params[:movie_id])
-    current_user.watch_progresses.create!(movie_id: @movie.id)
+    # @movie = Movie.find(params[:movie_id])
+    # current_user.watch_progresses.create!(movie_id: @movie.id)
+    current_user.watch_progresses.create!(movie_id: params[:movie_id])
+    redirect_back(fallback_location: root_path)
   end
 
   def destroy
-    @movie = Movie.find(params[:movie_id])
-    current_user.watch_progresses.find_by(movie_id: @movie.id).destroy!
+    # @movie = Movie.find(params[:movie_id])
+    # current_user.watch_progresses.find_by(movie_id: @movie.id).destroy!
+    current_user.watch_progresses.find_by(movie_id: params[:movie_id]).destroy!
+    redirect_back(fallback_location: root_path)
   end
 end

--- a/app/controllers/watch_progresses_controller.rb
+++ b/app/controllers/watch_progresses_controller.rb
@@ -1,15 +1,11 @@
 class WatchProgressesController < ApplicationController
   def create
-    # @movie = Movie.find(params[:movie_id])
-    # current_user.watch_progresses.create!(movie_id: @movie.id)
-    current_user.watch_progresses.create!(movie_id: params[:movie_id])
-    redirect_back(fallback_location: root_path)
+    @movie = Movie.find(params[:movie_id])
+    current_user.watch_progresses.create!(movie_id: @movie.id)
   end
 
   def destroy
-    # @movie = Movie.find(params[:movie_id])
-    # current_user.watch_progresses.find_by(movie_id: @movie.id).destroy!
-    current_user.watch_progresses.find_by(movie_id: params[:movie_id]).destroy!
-    redirect_back(fallback_location: root_path)
+    @movie = Movie.find(params[:movie_id])
+    current_user.watch_progresses.find_by(movie_id: @movie.id).destroy!
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -16,4 +16,9 @@ class Movie < ApplicationRecord
     validates :title
     validates :url
   end
+
+  def watched_by?(user)
+    watch_progresses.exists?(user_id: user.id)
+    # watch_progresses.any? { |watch_progress| watch_progress.user_id == user.id }
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -18,7 +18,6 @@ class Movie < ApplicationRecord
   end
 
   def watched_by?(user)
-    watch_progresses.exists?(user_id: user.id)
-    # watch_progresses.any? { |watch_progress| watch_progress.user_id == user.id }
+    watch_progresses.any? { |watch_progress| watch_progress.user_id == user.id }
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,4 +1,5 @@
 class Movie < ApplicationRecord
+  has_many :watch_progresses, dependent: :destroy
   enum genre: {
     invisible: 0, # 非表示
     basic: 1,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :read_progresses, dependent: :destroy
+  has_many :watch_progresses, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -1,0 +1,4 @@
+class WatchProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :movie
+end

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -1,4 +1,8 @@
 class WatchProgress < ApplicationRecord
   belongs_to :user
   belongs_to :movie
+  validates :user_id, uniqueness: {
+    scope: :movie_id,
+    message: "は同じ動画教材を2回以上視聴済みにはできません。"
+  }
 end

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -6,7 +6,11 @@
       </div>
     </div>
     <div class="card-body">
-      <a href="#" class="btn btn-block btn-secondary">視聴済みにする</a>
+      <% if movie.watched_by?(current_user) %>
+        <%= render "watched", movie: movie %>
+      <% else %>
+        <%= render "unwatched", movie: movie %>
+      <% end %>
       <p class="card-title mt-3 mb-5">レベル <%= movie_counter + 1 %> : <%= movie.title %></p>
     </div>
   </div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -5,13 +5,15 @@
         <iframe class="iframe-fluid" src="<%= movie.url %>" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
-    <div class="card-body">
-      <% if movie.watched_by?(current_user) %>
-        <%= render "watched", movie: movie %>
-      <% else %>
-        <%= render "unwatched", movie: movie %>
-      <% end %>
-      <p class="card-title mt-3 mb-5">レベル <%= movie_counter + 1 %> : <%= movie.title %></p>
+    <div class="card-body" >
+      <div class="watch-through-box mb-1" id="movie-<%= movie.id %>">
+        <% if movie.watched_by?(current_user) %>
+          <%= render "watched", movie: movie %>
+        <% else %>
+          <%= render "unwatched", movie: movie %>
+        <% end %>
+      </div>
+      <p class="card-title mt-3 mb-5">レベル <%= movie_counter + 1 %> : <%= movie.title %> </p>
     </div>
   </div>
 </div>

--- a/app/views/movies/_unwatched.html.erb
+++ b/app/views/movies/_unwatched.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "視聴済みにする", movie_watch_progresses_path(movie), class: 'btn btn-block btn-secondary', method: :post %>

--- a/app/views/movies/_unwatched.html.erb
+++ b/app/views/movies/_unwatched.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "視聴済みにする", movie_watch_progresses_path(movie), class: 'btn btn-block btn-secondary', method: :post %>
+<%= link_to "視聴済みにする", movie_watch_progresses_path(movie), class: 'btn btn-block btn-secondary', method: :post, remote: true %>

--- a/app/views/movies/_watched.html.erb
+++ b/app/views/movies/_watched.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "視聴済みを解除", movie_watch_progresses_path(movie), class: 'btn btn-block btn-secondary navbar-dark bg-primary', method: :delete %>
+<%= link_to "視聴済みを解除", movie_watch_progresses_path(movie), class: 'btn btn-block btn-secondary navbar-dark bg-primary', method: :delete, remote: true %>

--- a/app/views/movies/_watched.html.erb
+++ b/app/views/movies/_watched.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "視聴済みを解除", movie_watch_progresses_path(movie), class: 'btn btn-block btn-secondary navbar-dark bg-primary', method: :delete %>

--- a/app/views/watch_progresses/create.js.erb
+++ b/app/views/watch_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('movie-<%= @movie.id %>').innerHTML = '<%= j render("movies/watched", movie: @movie) %>'

--- a/app/views/watch_progresses/destroy.js.erb
+++ b/app/views/watch_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('movie-<%= @movie.id %>').innerHTML = '<%= j render("movies/unwatched", movie: @movie) %>'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -27,3 +27,6 @@ ja:
       read_progress:
         user: ユーザー
         text: テキスト教材
+      watch_progress:
+        user: ユーザー
+        movie: 動画教材

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
   resources :texts, only: [:index, :show] do
     resource :read_progresses, only: [:create, :destroy]
   end
-  resources :movies, only: [:index]
+  resources :movies, only: [:index] do
+    resource :watch_progresses, only: [:create, :destroy]
+  end
   root "texts#index"
 end

--- a/db/migrate/20210826012749_create_watch_progresses.rb
+++ b/db/migrate/20210826012749_create_watch_progresses.rb
@@ -1,0 +1,12 @@
+class CreateWatchProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :watch_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :movie, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :watch_progresses, [:user_id, :movie_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_18_030004) do
+ActiveRecord::Schema.define(version: 2021_08_26_012749) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,18 @@ ActiveRecord::Schema.define(version: 2021_08_18_030004) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  create_table "watch_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "movie_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["movie_id"], name: "index_watch_progresses_on_movie_id"
+    t.index ["user_id", "movie_id"], name: "index_watch_progresses_on_user_id_and_movie_id", unique: true
+    t.index ["user_id"], name: "index_watch_progresses_on_user_id"
+  end
+
   add_foreign_key "read_progresses", "texts"
   add_foreign_key "read_progresses", "users"
+  add_foreign_key "watch_progresses", "movies"
+  add_foreign_key "watch_progresses", "users"
 end


### PR DESCRIPTION
close #24  

## 実装内容

- 視聴済み機能に使用する `WatchProgress` モデルを作成
  - 外部キー設定を行い，ユニーク制約を入れてからマイグレーション
  - バリデーションをモデルに追加
  - 関連付けを入れる

- 動画教材一覧ページに視聴済み機能を実装
   - 非同期で処理できるようにすること

## 確認内容

- 以下を確認
```
rails c -s

# Railsコンソール起動後
user = User.first
movie, movie2 = Movie.limit(2)
WatchProgress.delete_all

user.watch_progresses.create!(movie_id: movie.id)
user.watch_progresses.create!(movie_id: movie2.id)

WatchProgress.count
#=> 2

movie.watch_progresses.create!(user_id: user.id)
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: Userは同じ動画教材を2回以上視聴済みにはできません

WatchProgress.create!
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: ユーザーを入力してください, 動画教材を入力してください
```
- 動画教材一覧ページの視聴済み機能が動作していることを確認

## 参考資料

-  [【やんばるエキスパート教材】モデルの関連付け その2（多対多）](https://www.yanbaru-code.com/texts/297)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
